### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/psqueues.cabal
+++ b/psqueues.cabal
@@ -85,6 +85,15 @@ Benchmark psqueues-benchmarks
     Type:           exitcode-stdio-1.0
     Hs-source-dirs: src benchmarks
     Main-is:        Main.hs
+
+    Other-modules:
+        BenchmarkTypes
+        Data.FingerTree.PSQueue.Benchmark
+        Data.HashPSQ.Benchmark
+        Data.IntPSQ.Benchmark
+        Data.OrdPSQ.Benchmark
+        Data.PSQueue.Benchmark
+
     Ghc-options:    -Wall
 
     Build-depends:


### PR DESCRIPTION
Currently, the benchmarks fail to build when obtained from Hackage, since the tarball does not include the modules on which `Main.hs` depends. This PR explicitly adds them to the `.cabal` file to fix this.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065