### PR TITLE
Lower the build depends version for hashable to >= 1.1.2.3

### DIFF
--- a/psqueues.cabal
+++ b/psqueues.cabal
@@ -64,9 +64,9 @@ Library
     Hs-source-dirs: src
 
     Build-depends:
-          base     >= 4.2   && < 5
-        , deepseq  >= 1.2   && < 1.5
-        , hashable >= 1.2.1 && < 1.3
+          base     >= 4.2     && < 5
+        , deepseq  >= 1.2     && < 1.5
+        , hashable >= 1.1.2.3 && < 1.3
 
     if impl(ghc>=6.10)
         Build-depends: ghc-prim


### PR DESCRIPTION
This PR lowers the build-depends version for [hashable](http://hackage.haskell.org/package/hashable) from 1.2.1 to 1.1.2.3.  I've tested locally that psqueues is still able to build with hashable-1.1.2.3.

We have an old version of GHC and hashable in our environment.  We would like to use psqueues without having to vendor it.